### PR TITLE
Add support for multiple servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # docker-pihole-controller
 
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Funixorn%2Fdocker-pihole-controller%2Fbadge&style=plastic)](https://actions-badge.atrox.dev/unixorn/docker-pihole-controller/goto)
+[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Funixorn%2Fdocker-pihole-controller%2Fbadge%3Fref%3Dmain&style=plastic)](https://actions-badge.atrox.dev/unixorn/docker-pihole-controller/goto?ref=main)
 
 Command line controller for [pi-hole](https://pi-hole.net/).
 
-Basically, I wanted a quick way to temporarily disable my piholes from the command line so I wouldn't have to hassle with opening a browser tab.
+Basically, I wanted a quick way to temporarily disable my pi holes from the command line so I wouldn't have to hassle with opening a browser tab for every pi hole every time I need to temporarily disable ad blocking on my home network.
 
 ## Usage
 
@@ -12,6 +12,8 @@ Basically, I wanted a quick way to temporarily disable my piholes from the comma
 
 The default number of seconds is 300.
 
-You can also specify a settings file with --configuration-file=/path/to/yaml/file. Currently the only settings are `password` and `server`.
+You can also specify a settings file with` --configuration-file=/path/to/yaml/file`.
+
+Currently the only settings are `password` and `servers`. Servers is a list of dns names or IP addresses of your pi holes.
 
 See the example `pihole-controller.yaml` in this repository for an example.

--- a/bin/pihole-controller
+++ b/bin/pihole-controller
@@ -6,8 +6,6 @@
 
 import argparse
 import logging
-import os
-import pprint
 import sys
 
 import pihole as ph
@@ -57,10 +55,10 @@ def parseCLI():
 
 def loadYamlFile(path):
   '''Return the data structure contained in a yaml file'''
-  with open(path) as yaml_file:
-    data = yaml.load(yaml_file, Loader=yaml.FullLoader)
+  with open(path) as yamlFile:
+    data = yaml.load(yamlFile, Loader=yaml.FullLoader)
     logging.debug('yaml data: %s', data)
-    return(data)
+    return data
 
 
 def disablePihole(servers, password, seconds=300):
@@ -76,10 +74,10 @@ def disablePihole(servers, password, seconds=300):
     logging.info('Connecting to %s', server)
     pihole = ph.PiHole(server)
     logging.debug('Authenticating to %s', server)
-    auth = pihole.authenticate(password)
+    pihole.authenticate(password)
     logging.debug('pihole version for %s = %s', server, pihole.getVersion())
     logging.debug('Disabling pihole for %s seconds', seconds)
-    result = pihole.disable(seconds)
+    pihole.disable(seconds)
 
 
 def main():

--- a/bin/pihole-controller
+++ b/bin/pihole-controller
@@ -63,12 +63,23 @@ def loadYamlFile(path):
     return(data)
 
 
-def disablePihole(server, password, seconds=300):
+def disablePihole(servers, password, seconds=300):
   '''Disable a pihole server'''
-  pihole = ph.PiHole(server)
-  auth = pihole.authenticate(password)
-  logging.debug('pihole version for %s = %s', server, pihole.getVersion())
-  result = pihole.disable(seconds)
+  if isinstance(servers, str):
+    servers = [servers]
+  elif not isinstance(servers, list):
+    logging.error('servers must be a list or string')
+    sys.exit(13)
+  logging.debug('Using servers %s', servers)
+
+  for server in servers:
+    logging.info('Connecting to %s', server)
+    pihole = ph.PiHole(server)
+    logging.debug('Authenticating to %s', server)
+    auth = pihole.authenticate(password)
+    logging.debug('pihole version for %s = %s', server, pihole.getVersion())
+    logging.debug('Disabling pihole for %s seconds', seconds)
+    result = pihole.disable(seconds)
 
 
 def main():
@@ -83,11 +94,11 @@ def main():
     password = loadYamlFile(path=args.configuration_file)['password']
 
   if args.server:
-    server = args.server
+    servers = args.server
   elif args.configuration_file:
-    server = loadYamlFile(path=args.configuration_file)['server']
+    servers = loadYamlFile(path=args.configuration_file)['servers']
 
-  disablePihole(server=server,
+  disablePihole(servers=servers,
                 password=password,
                 seconds=args.seconds)
 

--- a/pihole-controller.yaml
+++ b/pihole-controller.yaml
@@ -1,2 +1,5 @@
-server: YOUR_PIHOLE_DNS_NAME_OR_RAW_IP
+---
+servers:
+  - pihole1.example.com
+  - 192.168.1.100
 password: YOUR_PIHOLE_PASSWORD


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

If multiple servers are in the configuration file, disable ad blocking on all of them for the same length of time.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
