### PR TITLE
Add support for multiple --server arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Basically, I wanted a quick way to temporarily disable my pi holes from the comm
 
 `pihole-controller --server servername --password PASSWORD --seconds SECONDS_TO_DISABLE_PIHOLE`
 
-The default number of seconds is 300.
+The default number of seconds is 300. You may specify multiple `--server` arguments.
 
 You can also specify a settings file with` --configuration-file=/path/to/yaml/file`.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 task :default => [:usage]
 task :help => [:usage]
 task :build => [:multiarch_build]
+task :buildx => [:multiarch_build]
 task :b => [:multiarch_build]
 
 CONTAINER_NAME = 'unixorn/pihole-controller'
@@ -32,7 +33,7 @@ end
 desc 'Use buildx to make a test container'
 task :testbuild do
   puts "Building #{CONTAINER_NAME}"
-  sh %{ docker buildx build --platform linux/amd64 --push -t #{CONTAINER_NAME}:testing .}
+  sh %{ docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64 --push -t #{CONTAINER_NAME}:testing .}
   sh %{ docker pull #{CONTAINER_NAME}:testing }
 end
 

--- a/bin/pihole-controller
+++ b/bin/pihole-controller
@@ -36,7 +36,9 @@ def parseCLI():
                       type=int,
                       default=300)
   parser.add_argument('--server',
-                      help='server address')
+                      type=str,
+                      action='append',
+                      help='server address. Can be used multiple times if you have several pi holes with the same admin password')
 
   cliArgs = parser.parse_args()
   loglevel = getattr(logging, cliArgs.log_level.upper(), None)
@@ -90,11 +92,17 @@ def main():
     password = args.password
   elif args.configuration_file:
     password = loadYamlFile(path=args.configuration_file)['password']
+  else:
+    logging.error('You must specify a password either on the command line or in the configuration file')
+    sys.exit(7)
 
   if args.server:
     servers = args.server
   elif args.configuration_file:
     servers = loadYamlFile(path=args.configuration_file)['servers']
+  else:
+    logging.error('You must either specify servers on the command line or in the configuration file')
+    sys.exit(7)
 
   disablePihole(servers=servers,
                 password=password,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add support for multiple `--server` arguments

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
